### PR TITLE
fix(search.service): change default page to 0

### DIFF
--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -18,7 +18,7 @@ export class SearchService {
   private ratingFilter: string = '';
   private paymentFilter: string = '';
 
-  private currentPage: number = 1;
+  private currentPage: number = 0;
   private dataSource = new BehaviorSubject(this.results);
 
   private currentLatLng = '';

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -101,7 +101,7 @@ export class SearchService {
   }
 
   private resetPage(): void {
-    this.currentPage = 1;
+    this.currentPage = 0;
   }
 
 }


### PR DESCRIPTION
Pages in Algolia are 0-indexed.
By asking for page 1 by default, you're missing the most relevant results page.